### PR TITLE
Add layout elements to dashboard

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders dashboard heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /dashboard/i });
+  expect(heading).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,11 @@
 import React from 'react';
-import logo from './logo.svg';
 import './App.css';
+import Dashboard from './components/Dashboard';
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <Dashboard />
     </div>
   );
 }

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -1,0 +1,27 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.dashboard-header,
+.dashboard-footer {
+  background-color: #f8f8f8;
+  padding: 1rem;
+}
+
+.dashboard-content {
+  display: flex;
+  flex: 1;
+}
+
+.dashboard-sidebar {
+  width: 200px;
+  background-color: #f0f0f0;
+  padding: 1rem;
+}
+
+.dashboard-main {
+  flex: 1;
+  padding: 1rem;
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import './Dashboard.css';
+
+function Dashboard() {
+  return (
+    <div className="dashboard">
+      <header className="dashboard-header">Header</header>
+      <div className="dashboard-content">
+        <aside className="dashboard-sidebar">Sidebar</aside>
+        <main className="dashboard-main">
+          <h1>Dashboard</h1>
+          <p>Welcome to your dashboard!</p>
+        </main>
+      </div>
+      <footer className="dashboard-footer">Footer</footer>
+    </div>
+  );
+}
+
+export default Dashboard;


### PR DESCRIPTION
## Summary
- extend Dashboard layout with header, sidebar, and footer
- update styling for new layout

## Testing
- `npm install`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684c5883b52c8326a7f211a901d4b5d6