### PR TITLE
Implement pantry creation and selection

### DIFF
--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -21,6 +21,45 @@
   padding: 1rem;
 }
 
+.add-pantry {
+  margin-bottom: 1rem;
+}
+
+.add-pantry input {
+  width: 100%;
+  margin-bottom: 0.5rem;
+  padding: 0.25rem;
+  box-sizing: border-box;
+}
+
+.add-pantry button {
+  width: 100%;
+  padding: 0.25rem;
+}
+
+.pantry-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.pantry-list li {
+  margin-bottom: 0.5rem;
+}
+
+.pantry-list button {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.25rem;
+  cursor: pointer;
+}
+
+.pantry-list button.active {
+  background-color: #ddd;
+}
+
 .dashboard-main {
   flex: 1;
   padding: 1rem;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,15 +1,52 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './Dashboard.css';
 
 function Dashboard() {
+  const [pantries, setPantries] = useState<string[]>([]);
+  const [newPantry, setNewPantry] = useState('');
+  const [selectedPantry, setSelectedPantry] = useState<string | null>(null);
+
+  const addPantry = () => {
+    const trimmed = newPantry.trim();
+    if (trimmed.length === 0) return;
+    setPantries([...pantries, trimmed]);
+    setNewPantry('');
+  };
+
   return (
     <div className="dashboard">
       <header className="dashboard-header">Header</header>
       <div className="dashboard-content">
-        <aside className="dashboard-sidebar">Sidebar</aside>
+        <aside className="dashboard-sidebar">
+          <div className="add-pantry">
+            <input
+              type="text"
+              value={newPantry}
+              onChange={(e) => setNewPantry(e.target.value)}
+              placeholder="New pantry name"
+            />
+            <button onClick={addPantry}>Add Pantry</button>
+          </div>
+          <ul className="pantry-list">
+            {pantries.map((pantry, i) => (
+              <li key={i}>
+                <button
+                  className={pantry === selectedPantry ? 'active' : ''}
+                  onClick={() => setSelectedPantry(pantry)}
+                >
+                  {pantry}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </aside>
         <main className="dashboard-main">
-          <h1>Dashboard</h1>
-          <p>Welcome to your dashboard!</p>
+          <h1>{selectedPantry ? `${selectedPantry} Pantry` : 'Dashboard'}</h1>
+          {selectedPantry ? (
+            <p>You are viewing the {selectedPantry} pantry.</p>
+          ) : (
+            <p>Welcome to your dashboard!</p>
+          )}
         </main>
       </div>
       <footer className="dashboard-footer">Footer</footer>


### PR DESCRIPTION
## Summary
- let users create pantries from the sidebar
- render added pantries as selectable buttons in sidebar
- show selected pantry name in main content

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_684c5ae886688326a6efe5f9beca1b1a