### PR TITLE
Add pantry item management

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,37 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import App from './App';
 
 test('renders dashboard heading', () => {
   render(<App />);
   const heading = screen.getByRole('heading', { name: /dashboard/i });
   expect(heading).toBeInTheDocument();
+});
+
+test('can add, edit and delete an item', () => {
+  render(<App />);
+
+  fireEvent.change(screen.getByPlaceholderText(/new pantry name/i), {
+    target: { value: 'Test Pantry' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /add pantry/i }));
+
+  fireEvent.click(screen.getByRole('button', { name: 'Test Pantry' }));
+
+  fireEvent.change(screen.getByPlaceholderText(/new item/i), {
+    target: { value: 'Apple' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /add item/i }));
+
+  expect(screen.getByText('Apple')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+  const editInput = screen.getByDisplayValue('Apple');
+  fireEvent.change(editInput, { target: { value: 'Banana' } });
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+  expect(screen.getByText('Banana')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  expect(screen.queryByText('Banana')).not.toBeInTheDocument();
 });

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -64,3 +64,31 @@
   flex: 1;
   padding: 1rem;
 }
+
+.add-item {
+  margin-bottom: 1rem;
+}
+
+.add-item input {
+  width: 100%;
+  margin-bottom: 0.5rem;
+  padding: 0.25rem;
+  box-sizing: border-box;
+}
+
+.add-item button {
+  padding: 0.25rem 0.5rem;
+}
+
+.item-list {
+  list-style: none;
+  padding: 0;
+}
+
+.item-list li {
+  margin-bottom: 0.5rem;
+}
+
+.item-list button {
+  margin-left: 0.25rem;
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,16 +1,58 @@
 import React, { useState } from 'react';
 import './Dashboard.css';
 
+interface Pantry {
+  name: string;
+  items: string[];
+}
+
 function Dashboard() {
-  const [pantries, setPantries] = useState<string[]>([]);
+  const [pantries, setPantries] = useState<Pantry[]>([]);
   const [newPantry, setNewPantry] = useState('');
-  const [selectedPantry, setSelectedPantry] = useState<string | null>(null);
+  const [selectedPantry, setSelectedPantry] = useState<number | null>(null);
+  const [newItem, setNewItem] = useState('');
+  const [editingItemIndex, setEditingItemIndex] = useState<number | null>(null);
+  const [editingText, setEditingText] = useState('');
 
   const addPantry = () => {
     const trimmed = newPantry.trim();
     if (trimmed.length === 0) return;
-    setPantries([...pantries, trimmed]);
+    setPantries([...pantries, { name: trimmed, items: [] }]);
     setNewPantry('');
+  };
+
+  const addItem = () => {
+    if (selectedPantry === null) return;
+    const trimmed = newItem.trim();
+    if (trimmed.length === 0) return;
+    const updated = [...pantries];
+    updated[selectedPantry].items.push(trimmed);
+    setPantries(updated);
+    setNewItem('');
+  };
+
+  const deleteItem = (index: number) => {
+    if (selectedPantry === null) return;
+    const updated = [...pantries];
+    updated[selectedPantry].items.splice(index, 1);
+    setPantries(updated);
+  };
+
+  const startEditItem = (index: number) => {
+    if (selectedPantry === null) return;
+    setEditingItemIndex(index);
+    setEditingText(pantries[selectedPantry].items[index]);
+  };
+
+  const saveItem = (index: number) => {
+    if (selectedPantry === null) return;
+    const trimmed = editingText.trim();
+    if (trimmed.length === 0) return;
+    const updated = [...pantries];
+    updated[selectedPantry].items[index] = trimmed;
+    setPantries(updated);
+    setEditingItemIndex(null);
+    setEditingText('');
   };
 
   return (
@@ -31,19 +73,55 @@ function Dashboard() {
             {pantries.map((pantry, i) => (
               <li key={i}>
                 <button
-                  className={pantry === selectedPantry ? 'active' : ''}
-                  onClick={() => setSelectedPantry(pantry)}
+                  className={i === selectedPantry ? 'active' : ''}
+                  onClick={() => setSelectedPantry(i)}
                 >
-                  {pantry}
+                  {pantry.name}
                 </button>
               </li>
             ))}
           </ul>
         </aside>
         <main className="dashboard-main">
-          <h1>{selectedPantry ? `${selectedPantry} Pantry` : 'Dashboard'}</h1>
-          {selectedPantry ? (
-            <p>You are viewing the {selectedPantry} pantry.</p>
+          <h1>
+            {selectedPantry !== null
+              ? `${pantries[selectedPantry].name} Pantry`
+              : 'Dashboard'}
+          </h1>
+          {selectedPantry !== null ? (
+            <div className="item-section">
+              <div className="add-item">
+                <input
+                  type="text"
+                  value={newItem}
+                  onChange={(e) => setNewItem(e.target.value)}
+                  placeholder="New item"
+                />
+                <button onClick={addItem}>Add Item</button>
+              </div>
+              <ul className="item-list">
+                {pantries[selectedPantry].items.map((item, i) => (
+                  <li key={i}>
+                    {editingItemIndex === i ? (
+                      <>
+                        <input
+                          type="text"
+                          value={editingText}
+                          onChange={(e) => setEditingText(e.target.value)}
+                        />
+                        <button onClick={() => saveItem(i)}>Save</button>
+                      </>
+                    ) : (
+                      <>
+                        <span>{item}</span>
+                        <button onClick={() => startEditItem(i)}>Edit</button>
+                      </>
+                    )}
+                    <button onClick={() => deleteItem(i)}>Delete</button>
+                  </li>
+                ))}
+              </ul>
+            </div>
           ) : (
             <p>Welcome to your dashboard!</p>
           )}


### PR DESCRIPTION
## Summary
- add item management logic to Dashboard
- add styles for item management
- test ability to add, edit and delete pantry items

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684c5bd357148326bdfe7afe10dd53b4