### PR TITLE
Add photo-based OpenAI item recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+## OpenAI Integration
+
+The dashboard supports adding items from photos using the OpenAI Vision API.
+Provide an API key in an environment variable named `REACT_APP_OPENAI_API_KEY`.
+When running locally create a `.env` file with:
+
+```
+REACT_APP_OPENAI_API_KEY=your_api_key_here
+```
+
+Selecting **Add Item from Photo** will prompt for an image and the detected
+product name will be added to the selected pantry.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -18,10 +18,14 @@ test('can add, edit and delete an item', () => {
 
   fireEvent.click(screen.getByRole('button', { name: 'Test Pantry' }));
 
+  expect(
+    screen.getByRole('button', { name: /add item from photo/i })
+  ).toBeInTheDocument();
+
   fireEvent.change(screen.getByPlaceholderText(/new item/i), {
     target: { value: 'Apple' },
   });
-  fireEvent.click(screen.getByRole('button', { name: /add item/i }));
+  fireEvent.click(screen.getByRole('button', { name: /^add item$/i }));
 
   expect(screen.getByText('Apple')).toBeInTheDocument();
 

--- a/src/openAI.ts
+++ b/src/openAI.ts
@@ -1,0 +1,36 @@
+export async function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+export async function extractItemName(file: File): Promise<string | null> {
+  const image = await fileToDataUrl(file);
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.REACT_APP_OPENAI_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'gpt-4-vision-preview',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Identify the product name in this image and return only the name.' },
+            { type: 'image_url', image_url: image },
+          ],
+        },
+      ],
+      max_tokens: 20,
+    }),
+  });
+
+  if (!response.ok) return null;
+  const data = await response.json();
+  return data.choices?.[0]?.message?.content?.trim() || null;
+}


### PR DESCRIPTION
## Summary
- integrate OpenAI vision API helper
- support uploading a photo to add items
- show loading state when processing photos
- update tests for new button
- document how to set `REACT_APP_OPENAI_API_KEY`

## Testing
- `npm test -- -u`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684c5d1807388326bd54a32489aeca70