### PR TITLE
Add toast notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-scripts": "5.0.1",
+        "react-toastify": "^11.0.5",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       }
@@ -5246,6 +5247,15 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -12984,6 +12994,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
+    "react-toastify": "^11.0.5",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import './App.css';
 import Dashboard from './components/Dashboard';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 function App() {
   return (
     <div className="App">
       <Dashboard />
+      <ToastContainer position="top-right" />
     </div>
   );
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import './Dashboard.css';
 import { extractItemName } from '../openAI';
+import { toast } from 'react-toastify';
 
 interface Pantry {
   name: string;
@@ -19,26 +20,41 @@ function Dashboard() {
 
   const addPantry = () => {
     const trimmed = newPantry.trim();
-    if (trimmed.length === 0) return;
+    if (trimmed.length === 0) {
+      toast.error('Pantry name cannot be empty');
+      return;
+    }
     setPantries([...pantries, { name: trimmed, items: [] }]);
     setNewPantry('');
+    toast.success('Pantry added');
   };
 
   const addItem = () => {
-    if (selectedPantry === null) return;
+    if (selectedPantry === null) {
+      toast.error('Select a pantry first');
+      return;
+    }
     const trimmed = newItem.trim();
-    if (trimmed.length === 0) return;
+    if (trimmed.length === 0) {
+      toast.error('Item name cannot be empty');
+      return;
+    }
     const updated = [...pantries];
     updated[selectedPantry].items.push(trimmed);
     setPantries(updated);
     setNewItem('');
+    toast.success('Item added');
   };
 
   const deleteItem = (index: number) => {
-    if (selectedPantry === null) return;
+    if (selectedPantry === null) {
+      toast.error('Select a pantry first');
+      return;
+    }
     const updated = [...pantries];
     updated[selectedPantry].items.splice(index, 1);
     setPantries(updated);
+    toast.success('Item deleted');
   };
 
   const startEditItem = (index: number) => {
@@ -48,20 +64,33 @@ function Dashboard() {
   };
 
   const saveItem = (index: number) => {
-    if (selectedPantry === null) return;
+    if (selectedPantry === null) {
+      toast.error('Select a pantry first');
+      return;
+    }
     const trimmed = editingText.trim();
-    if (trimmed.length === 0) return;
+    if (trimmed.length === 0) {
+      toast.error('Item name cannot be empty');
+      return;
+    }
     const updated = [...pantries];
     updated[selectedPantry].items[index] = trimmed;
     setPantries(updated);
     setEditingItemIndex(null);
     setEditingText('');
+    toast.success('Item updated');
   };
 
   const handlePhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (selectedPantry === null) return;
+    if (selectedPantry === null) {
+      toast.error('Select a pantry first');
+      return;
+    }
     const file = e.target.files?.[0];
-    if (!file) return;
+    if (!file) {
+      toast.error('No file selected');
+      return;
+    }
     setLoading(true);
     try {
       const name = await extractItemName(file);
@@ -69,7 +98,12 @@ function Dashboard() {
         const updated = [...pantries];
         updated[selectedPantry].items.push(name);
         setPantries(updated);
+        toast.success('Item added from photo');
+      } else {
+        toast.error('Could not detect item');
       }
+    } catch {
+      toast.error('Failed to process image');
     } finally {
       setLoading(false);
       e.target.value = '';

--- a/src/openAI.ts
+++ b/src/openAI.ts
@@ -9,28 +9,32 @@ export async function fileToDataUrl(file: File): Promise<string> {
 
 export async function extractItemName(file: File): Promise<string | null> {
   const image = await fileToDataUrl(file);
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${process.env.REACT_APP_OPENAI_API_KEY}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: 'gpt-4-vision-preview',
-      messages: [
-        {
-          role: 'user',
-          content: [
-            { type: 'text', text: 'Identify the product name in this image and return only the name.' },
-            { type: 'image_url', image_url: image },
-          ],
-        },
-      ],
-      max_tokens: 20,
-    }),
-  });
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.REACT_APP_OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-4-vision-preview',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Identify the product name in this image and return only the name.' },
+              { type: 'image_url', image_url: image },
+            ],
+          },
+        ],
+        max_tokens: 20,
+      }),
+    });
 
-  if (!response.ok) return null;
-  const data = await response.json();
-  return data.choices?.[0]?.message?.content?.trim() || null;
+    if (!response.ok) return null;
+    const data = await response.json();
+    return data.choices?.[0]?.message?.content?.trim() || null;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary
- integrate react-toastify
- show notifications for CRUD actions in the dashboard
- display notification container in `App`
- handle OpenAI errors better

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c60b65ee88326ae44356fc2f19f15