### PR TITLE
Fix OpenAI vision call

### DIFF
--- a/src/openAI.ts
+++ b/src/openAI.ts
@@ -16,13 +16,16 @@ export async function extractItemName(file: File): Promise<string | null> {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      model: 'gpt-4-vision-preview',
+      model: 'gpt-4o',
       messages: [
         {
           role: 'user',
           content: [
-            { type: 'text', text: 'Identify the product name in this image and return only the name.' },
-            { type: 'image_url', image_url: image },
+            {
+              type: 'text',
+              text: 'Identify the product name in this image and return only the name.'
+            },
+            { type: 'image_url', image_url: { url: image } },
           ],
         },
       ],


### PR DESCRIPTION
## Summary
- correct `extractItemName` to send vision image URL object
- switch to latest `gpt-4o` model

## Testing
- `npm test --silent`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684c65a8d5dc832680d8d1ef4af9c36e